### PR TITLE
Disable right column text animations

### DIFF
--- a/source/javascripts/all.js
+++ b/source/javascripts/all.js
@@ -12,38 +12,21 @@ var $greetingLeftColumnImage = $('.js-greeting-left-column-image');
 var $greetingRightColumnContent = $('.js-greeting-right-column-content');
 var $socialMediaLinks = $('.js-social-media-links');
 var $socialMediaLinkAnchor = $('.js-social-media-links-anchor');
-var $page = $('.js-page');
 
 //
 // Images loaded
 //
-$(function(){
-  'use strict';
-
-  $greetingLeftColumnImage.imagesLoaded({ background: true }, function() {
-    $greetingLeftColumnImageContainer.addClass('greeting__left-column-image-container--is-finished-loading');
-    $socialMediaLinks.addClass('social-media-links--is-ready');
-    setTimeout( function() {
-      $greetingRightColumnContent.addClass('greeting__right-column-content--is-visible');
-    }, 500);
-
-    setTimeout( function() {
-      $greetingRightColumnContent.addClass('greeting__right-column-content--is-visible');
-    }, 500);
-
-    // Apply modfier class to the body element once animations have completed (~1900ms)
-    // This is a temporary hack to fix font-smoothing in Chrome
-    // http://stackoverflow.com/questions/40335130/chrome-ignoring-font-smoothing-antialiased
-    setTimeout( function() {
-      $page.addClass('page--is-finished-animating'); // For enabling font antialiasing only once animations have completed
-    }, 1900);
-  });
+$greetingLeftColumnImage.imagesLoaded({ background: true }, function() {
+  $greetingLeftColumnImageContainer.addClass('greeting__left-column-image-container--is-finished-loading');
+  $socialMediaLinks.addClass('social-media-links--is-ready');
+  setTimeout( function() {
+    $greetingRightColumnContent.addClass('greeting__right-column-content--is-visible');
+  }, 500);
 });
 
 //
 // Social media component
 //
-
 $socialMediaLinkAnchor.mouseover(function() {
   $(this).addClass('social-media-links__anchor--is-focused');
   $socialMediaLinks.addClass('social-media-links--has-hovered-anchor');

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -10,7 +10,7 @@
     <%= stylesheet_link_tag :all %>
   </head>
 
-  <body class="page page--is-<%= page_classes %> js-page">
+  <body class="page page--is-<%= page_classes %>">
     <main id="main" role="main">
       <%= yield %>
     </main>

--- a/source/stylesheets/base/_page.scss
+++ b/source/stylesheets/base/_page.scss
@@ -5,13 +5,10 @@ html {
 }
 
 .page {
+  -webkit-font-smoothing: antialiased;
   color: lighten(#252A2E, 25%);
   padding: 0;
   margin: 0;
-
-  &--is-finished-animating {
-    -webkit-font-smoothing: antialiased;
-  }
 
   @include media-query(portable) {
     font-size: 7px;

--- a/source/stylesheets/components/_greeting.scss
+++ b/source/stylesheets/components/_greeting.scss
@@ -91,7 +91,6 @@ $greeting-left-column-background-color:  #252A2E;
     padding-right: 10rem;
     padding-top: 10rem;
     position: relative;
-    transform: translateZ(0);
     width: 60%;
 
     @include media-query(palm) {
@@ -131,15 +130,15 @@ $greeting-left-column-background-color:  #252A2E;
     max-width: 480px;
 
     * {
-      transform: translateY(50px);
-      transition-duration: 1000ms, 1000ms;
-      transition-property: opacity, transform;
-      transition-timing-function: $variables-primary-easing;
-      opacity: 0;
+      // transform: translateY(50px);
+      // transition-duration: 1000ms, 1000ms;
+      // transition-property: opacity, transform;
+      // transition-timing-function: $variables-primary-easing;
+      // opacity: 0;
 
       @for $i from 1 to 6 {
         &:nth-child(#{$i}) {
-          transition-delay: $i * $greeting-transition-delay-margin + 1;
+          // transition-delay: $i * $greeting-transition-delay-margin + 1;
         }
       }
     }


### PR DESCRIPTION
Turns out if you animate text in Chrome, it can disable font-smoothing and degrade text rendering depending on the font / OS :(

http://stackoverflow.com/questions/12502234/how-to-prevent-webkit-text-rendering-change-during-css-transition